### PR TITLE
fix require activesupport 4.2.0

### DIFF
--- a/bin/wechat
+++ b/bin/wechat
@@ -5,7 +5,8 @@ $LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
 
 require 'thor'
 require "wechat-rails"
-require 'json'  
+require 'json'
+require 'active_support'
 require "active_support/core_ext"
 require 'fileutils'
 require 'yaml'


### PR DESCRIPTION
rails 4.2.0 环境下会出现下面的错误。 /bin/wechat 添加 `require 'activesupport'` 就可以工作了，参考 http://guides.rubyonrails.org/active_support_core_extensions.html#loading-all-core-extensions 。

```
> wechat
/Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext/module/deprecation.rb:21:in `deprecate': uninitialized constant ActiveSupport::Deprecation (NameError)
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext/class/delegating_attributes.rb:26:in `<class:Class>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext/class/delegating_attributes.rb:6:in `<top (required)>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext/class.rb:2:in `require'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext/class.rb:2:in `<top (required)>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:2:in `require'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:1:in `each'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/gems/activesupport-4.2.0/lib/active_support/core_ext.rb:1:in `<top (required)>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bundler/gems/wechat-rails-d7ad86164518/bin/wechat:9:in `require'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bundler/gems/wechat-rails-d7ad86164518/bin/wechat:9:in `<top (required)>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bin/wechat:23:in `load'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bin/wechat:23:in `<main>'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bin/ruby_executable_hooks:15:in `eval'
	from /Users/basten/.rvm/gems/ruby-2.1.5@sales_man/bin/ruby_executable_hooks:15:in `<main>'
```