### PR TITLE
fix error uninitialized constant ActiveSupport::Autoload (NameError)

### DIFF
--- a/bin/wechat
+++ b/bin/wechat
@@ -6,6 +6,7 @@ $LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
 require 'thor'
 require "wechat-rails"
 require 'json'  
+require "active_support"
 require "active_support/core_ext"
 require 'fileutils'
 require 'yaml'


### PR DESCRIPTION
➜  wechat git:(master) ✗ wechat menu                                                                            
/Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/number_helper.rb:1:in `<top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext/numeric/conversions.rb:2:in `require'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext/numeric/conversions.rb:2:in `<top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext/numeric.rb:3:in `require'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext/numeric.rb:3:in `<top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext.rb:2:in `require'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext.rb:2:in `block in <top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext.rb:1:in `each'
	from /Users/apple/.rvm/gems/ruby-2.1.1/gems/activesupport-4.2.3/lib/active_support/core_ext.rb:1:in `<top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bundler/gems/wechat-rails-811c17dcd7ab/bin/wechat:9:in `require'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bundler/gems/wechat-rails-811c17dcd7ab/bin/wechat:9:in `<top (required)>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bin/wechat:23:in `load'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bin/wechat:23:in `<main>'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `eval'
	from /Users/apple/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `<main>'

to fix this error, we need add require 'active_support'